### PR TITLE
Skip QEMU setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         git checkout main
         git pull
     - name: Set up QEMU
-      if: matrix.platform != 'linux/amd64'
+      if: matrix.platform != 'linux/amd64' && matrix.platform != 'linux/386'
       uses: docker/setup-qemu-action@v2
       with:
         platforms: ${{ matrix.platform }}


### PR DESCRIPTION
32-bit binaries should run natively on the x86_64 runners provided by GitHub.